### PR TITLE
feat(mobile): add sign-in entry, mobile nav menu, responsive workspace

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -75,19 +75,19 @@ export default function DashboardPage() {
   const firstName = user?.user_metadata?.first_name ?? user?.email?.split('@')[0] ?? 'der';
 
   return (
-    <div className="bg-paper-grain min-h-screen px-6 lg:px-10 py-8">
+    <div className="bg-paper-grain min-h-screen px-4 sm:px-6 lg:px-10 py-8">
       <div className="max-w-7xl mx-auto">
         {/* HEADER */}
-        <div className="flex justify-between items-start mb-8">
+        <div className="flex flex-col gap-4 sm:flex-row sm:justify-between sm:items-start mb-8">
           <div>
             <div className="cap text-ink-mute mb-1.5">
               {fmtDate(new Date().toISOString()).slice(3)}
             </div>
-            <h1 className="font-display text-[36px] md:text-[44px] m-0 tracking-[-0.02em]">
+            <h1 className="font-display text-[32px] sm:text-[36px] md:text-[44px] m-0 tracking-[-0.02em]">
               {greeting}, <em>{firstName}</em>.
             </h1>
           </div>
-          <Link href="/invoices/create">
+          <Link href="/invoices/create" className="self-start sm:self-auto">
             <Button variant="clay" size="default">+ Ny faktura</Button>
           </Link>
         </div>
@@ -146,7 +146,7 @@ export default function DashboardPage() {
         </div>
 
         <div className="border-t border-ink">
-          <div className="grid grid-cols-[100px_1fr_120px_90px_110px_24px] py-2.5 cap text-ink-mute border-b border-ink/12">
+          <div className="hidden md:grid grid-cols-[100px_1fr_120px_90px_110px_24px] py-2.5 cap text-ink-mute border-b border-ink/12">
             <div>Nummer</div>
             <div>Kunde</div>
             <div className="text-right">Beløp</div>
@@ -163,20 +163,38 @@ export default function DashboardPage() {
               <Link
                 href={`/invoices/${inv.id}`}
                 key={inv.id}
-                className="grid grid-cols-[100px_1fr_120px_90px_110px_24px] py-4 border-b border-ink/8 items-center hover:bg-paper-2 transition-colors"
+                className="block md:grid md:grid-cols-[100px_1fr_120px_90px_110px_24px] py-4 border-b border-ink/8 md:items-center hover:bg-paper-2 transition-colors"
               >
-                <div className="font-mono text-[13px] text-ink-3">{inv.invoice_number ?? '—'}</div>
-                <div className="text-[15px]">{inv.client?.name ?? '—'}</div>
-                <div className="font-mono text-right text-sm">
+                {/* Mobile card layout */}
+                <div className="md:hidden flex flex-col gap-1.5">
+                  <div className="flex justify-between items-start gap-3">
+                    <div className="text-[15px] font-medium">{inv.client?.name ?? '—'}</div>
+                    <StatusPill status={inv.status} />
+                  </div>
+                  <div className="flex justify-between items-baseline gap-3 text-[13px] text-ink-3">
+                    <span className="font-mono">{inv.invoice_number ?? '—'}</span>
+                    <span className="font-mono">
+                      kr {fmtKr(Number(inv.total_amount ?? 0), false)}
+                    </span>
+                  </div>
+                  <div className="font-mono text-[12px] text-ink-mute">
+                    {inv.due_date ? `Forfall ${fmtDate(inv.due_date).slice(0, 5)}` : '—'}
+                  </div>
+                </div>
+
+                {/* Desktop grid cells */}
+                <div className="hidden md:block font-mono text-[13px] text-ink-3">{inv.invoice_number ?? '—'}</div>
+                <div className="hidden md:block text-[15px]">{inv.client?.name ?? '—'}</div>
+                <div className="hidden md:block font-mono text-right text-sm">
                   kr {fmtKr(Number(inv.total_amount ?? 0), false)}
                 </div>
-                <div className="font-mono text-right text-[13px] text-ink-3">
+                <div className="hidden md:block font-mono text-right text-[13px] text-ink-3">
                   {inv.due_date ? fmtDate(inv.due_date).slice(0, 5) : '—'}
                 </div>
-                <div className="text-right">
+                <div className="hidden md:block text-right">
                   <StatusPill status={inv.status} />
                 </div>
-                <div className="text-right text-ink-mute">›</div>
+                <div className="hidden md:block text-right text-ink-mute">›</div>
               </Link>
             ))
           )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Wordmark } from "@/components/brand/Wordmark";
+import { Mark } from "@/components/brand/Mark";
 import {
   ReceiptBird,
   CitrusCalc,
@@ -13,6 +14,31 @@ import { t } from "@/lib/i18n.server";
 export default function LandingPage() {
   return (
     <div className="bg-paper-grain text-ink">
+      {/* TOP BAR — logo + sign-in entry point */}
+      <header className="border-b border-ink/10 bg-paper/80 backdrop-blur-sm sticky top-0 z-40">
+        <div className="max-w-7xl mx-auto py-4 px-6 lg:px-12 flex justify-between items-center">
+          <Link
+            href="/"
+            className="flex items-center gap-3 hover:opacity-80 transition-opacity"
+          >
+            <Mark size={28} />
+            <Wordmark size={0.7} />
+          </Link>
+          <div className="flex items-center gap-2 sm:gap-3">
+            <Link href="/sign-in">
+              <Button variant="outline" size="sm">
+                {t("Sign In")}
+              </Button>
+            </Link>
+            <Link href="/sign-up" className="hidden sm:inline-flex">
+              <Button variant="clay" size="sm">
+                {t("Get Started")}
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </header>
+
       {/* HERO */}
       <section className="grid grid-cols-1 lg:grid-cols-[1.15fr_1fr] gap-12 px-6 lg:px-12 pt-16 pb-24 max-w-7xl mx-auto items-center">
         <div>

--- a/src/components/InvoiceDetailClient.tsx
+++ b/src/components/InvoiceDetailClient.tsx
@@ -220,14 +220,16 @@ export function InvoiceDetailClient({ invoice }: InvoiceDetailClientProps) {
           <ArrowLeft className="h-4 w-4 mr-2" />
           {t('Back to Invoices')}
         </Link>
-        <div className="flex justify-between items-start">
+        <div className="flex flex-col gap-4 md:flex-row md:justify-between md:items-start">
           <div>
-            <h1 className="text-3xl font-bold">{t('Invoice')} {invoice.invoice_number}</h1>
-            <p className="text-muted-foreground">
+            <h1 className="text-2xl md:text-3xl font-bold break-words">
+              {t('Invoice')} {invoice.invoice_number}
+            </h1>
+            <p className="text-muted-foreground text-sm md:text-base">
               {t('Created on')} {new Date(invoice.created_at).toLocaleDateString()}
             </p>
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="flex flex-wrap items-center gap-2 md:gap-3">
             {companySettings && (
               <PDFDownloadLink
                 document={

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { createClient } from '@/utils/supabase/client';
 import { useEffect, useState } from 'react';
+import { Menu, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { t } from '@/lib/i18n';
 import { Wordmark } from '@/components/brand/Wordmark';
@@ -15,6 +16,7 @@ export default function Navbar() {
   const pathname = usePathname();
   const supabase = createClient();
   const [user, setUser] = useState<any>(null);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   useEffect(() => {
     const getUser = async () => {
@@ -30,6 +32,11 @@ export default function Navbar() {
       listener?.subscription.unsubscribe();
     };
   }, []);
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
 
   // Hide chrome on the marketing landing page and on public invoice pages.
   if (pathname === '/' || pathname?.startsWith('/i/')) return null;
@@ -47,6 +54,21 @@ export default function Navbar() {
         : 'text-ink-3 hover:text-ink',
     );
 
+  const mobileLinkClass = (active: boolean) =>
+    cn(
+      'block px-6 py-3 text-base font-medium transition-colors border-l-2',
+      active
+        ? 'text-ink border-clay bg-paper-2'
+        : 'text-ink-3 border-transparent hover:text-ink hover:bg-paper-2',
+    );
+
+  const navItems: Array<[string, string]> = [
+    ['/dashboard', t('Dashboard')],
+    ['/invoices', t('Invoices')],
+    ['/clients', t('Clients')],
+    ['/settings', t('Settings')],
+  ];
+
   return (
     <header className="border-b border-ink/10 bg-paper/80 backdrop-blur-sm sticky top-0 z-40">
       <div className="container mx-auto py-4 px-6 flex justify-between items-center">
@@ -59,25 +81,35 @@ export default function Navbar() {
         </Link>
         {user && (
           <nav className="hidden md:flex items-center space-x-6">
-            <Link href="/dashboard" className={navLinkClass(pathname === '/dashboard')}>
-              {t('Dashboard')}
-            </Link>
-            <Link href="/invoices" className={navLinkClass(pathname === '/invoices')}>
-              {t('Invoices')}
-            </Link>
-            <Link href="/clients" className={navLinkClass(pathname === '/clients')}>
-              {t('Clients')}
-            </Link>
-            <Link href="/settings" className={navLinkClass(pathname === '/settings')}>
-              {t('Settings')}
-            </Link>
+            {navItems.map(([href, label]) => (
+              <Link key={href} href={href} className={navLinkClass(pathname === href)}>
+                {label}
+              </Link>
+            ))}
           </nav>
         )}
-        <div className="flex items-center space-x-4">
+        <div className="flex items-center gap-2">
           {user ? (
-            <Button variant="outline" size="sm" onClick={handleSignOut}>
-              {t('Sign Out')}
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleSignOut}
+                className="hidden md:inline-flex"
+              >
+                {t('Sign Out')}
+              </Button>
+              <button
+                type="button"
+                onClick={() => setMobileOpen((v) => !v)}
+                className="md:hidden inline-flex items-center justify-center h-10 w-10 rounded-sm text-ink hover:bg-ink/[.04]"
+                aria-label={mobileOpen ? t('Close menu') : t('Open menu')}
+                aria-expanded={mobileOpen}
+                aria-controls="mobile-nav"
+              >
+                {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+              </button>
+            </>
           ) : (
             <Link href="/sign-in">
               <Button variant="outline" size="sm">{t('Sign In')}</Button>
@@ -85,6 +117,33 @@ export default function Navbar() {
           )}
         </div>
       </div>
+
+      {user && mobileOpen && (
+        <nav
+          id="mobile-nav"
+          className="md:hidden border-t border-ink/10 bg-paper"
+        >
+          {navItems.map(([href, label]) => (
+            <Link
+              key={href}
+              href={href}
+              className={mobileLinkClass(pathname === href)}
+            >
+              {label}
+            </Link>
+          ))}
+          <div className="px-6 py-3 border-t border-ink/10">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSignOut}
+              className="w-full"
+            >
+              {t('Sign Out')}
+            </Button>
+          </div>
+        </nav>
+      )}
     </header>
   );
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -5,6 +5,8 @@ const dict: Record<Locale, Record<string, string>> = {
     // — Auth / nav —
     "Sign In":  "Logg inn",
     "Sign Out": "Logg ut",
+    "Open menu": "Åpne meny",
+    "Close menu": "Lukk meny",
     "Get Started": "Kom i gang",
     "Start for Free": "Start gratis",
     "Learn More": "Lær mer",
@@ -246,6 +248,8 @@ const dict: Record<Locale, Record<string, string>> = {
   en: {
     "Sign In":  "Sign in",
     "Sign Out": "Sign out",
+    "Open menu": "Open menu",
+    "Close menu": "Close menu",
     "Dashboard": "Dashboard",
     "Invoices": "Invoices",
     "Clients":  "Clients",


### PR DESCRIPTION
- Landing page now has a sticky header with a clear "Logg inn" button
  so visitors can find their way back in without scrolling through the
  marketing page.
- Navbar gains a hamburger menu on viewports below md, exposing
  Dashboard / Invoices / Clients / Settings and Sign Out which were
  previously hidden on mobile.
- Invoice detail header stacks title and action buttons on small
  screens and wraps the action row instead of overflowing.
- Dashboard switches the invoice list from a fixed 6-column grid to a
  card-style row on mobile so it fits below ~640px.