### PR TITLE
Phase 5 — VAT/EHF/money/idempotency/GDPR correctness

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAuthenticatedUser } from '@/lib/auth';
+import { createClient } from '@/utils/supabase/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+
+function getSupabaseAdmin() {
+  return createAdminClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+/**
+ * POST /api/account/delete
+ *
+ * GDPR Art.17 erasure. Requires explicit confirmation in the body:
+ *   { "confirm": "SLETT" }
+ *
+ * anonymize_user_account() scrubs the user's PII and anonymizes (does NOT
+ * delete) invoices that bokføringsloven §13 requires us to retain ~5 years.
+ * Afterwards we BAN — but do not hard-delete — the auth.users row: profiles and
+ * company_settings cascade from it and must survive for the retained invoices,
+ * so a CASCADE delete would breach the retention obligation. Banning prevents
+ * any further sign-in while keeping the anonymized records intact.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAuthenticatedUser();
+
+    const body = await request.json().catch(() => ({}));
+    if (body?.confirm !== 'SLETT') {
+      return NextResponse.json(
+        { error: 'Bekreftelse mangler. Send { "confirm": "SLETT" } for å bekrefte sletting.' },
+        { status: 400 },
+      );
+    }
+
+    const supabase = await createClient();
+    const { data, error } = await supabase.rpc('anonymize_user_account', { p_user_id: user.id });
+    if (error || data?.ok === false) {
+      console.error('anonymize_user_account failed:', error);
+      return NextResponse.json({ error: 'Kunne ikke slette kontoen. Prøv igjen senere.' }, { status: 500 });
+    }
+
+    // Ban the auth user (~100 years) so they can no longer sign in, without
+    // cascading away the retained company_settings/profiles rows.
+    const admin = getSupabaseAdmin();
+    const { error: banError } = await admin.auth.admin.updateUserById(user.id, { ban_duration: '876000h' });
+    if (banError) {
+      // PII is already anonymized; failing to ban is non-fatal but logged loudly.
+      console.error('Failed to ban auth user after anonymization:', banError);
+    }
+
+    // End the current session so the now-anonymized account is logged out.
+    await supabase.auth.signOut();
+
+    return NextResponse.json({
+      message: 'Kontoen din er slettet. Personopplysninger er anonymisert; fakturaer beholdes anonymt i 5 år iht. bokføringsloven.',
+      data,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('redirect')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    console.error('Error deleting account:', error);
+    return NextResponse.json({ error: 'Kunne ikke slette kontoen.' }, { status: 500 });
+  }
+}

--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -16,12 +16,13 @@ function getSupabaseAdmin() {
  * GDPR Art.17 erasure. Requires explicit confirmation in the body:
  *   { "confirm": "SLETT" }
  *
- * anonymize_user_account() scrubs the user's PII and anonymizes (does NOT
- * delete) invoices that bokføringsloven §13 requires us to retain ~5 years.
- * Afterwards we BAN — but do not hard-delete — the auth.users row: profiles and
- * company_settings cascade from it and must survive for the retained invoices,
- * so a CASCADE delete would breach the retention obligation. Banning prevents
- * any further sign-in while keeping the anonymized records intact.
+ * anonymize_user_account() locks the account: it marks the profile erased and
+ * scrubs the seller's own non-required contact fields, but leaves clients and
+ * invoices UNALTERED — bokføringsloven §13 requires those to be retained
+ * complete for ~5 years (GDPR Art.17(3)(b)). Afterwards we BAN — but do not
+ * hard-delete — the auth.users row: profiles and company_settings cascade from
+ * it and must survive for the retained invoices, so a CASCADE delete would
+ * breach the retention obligation. Banning prevents any further sign-in.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -55,7 +56,7 @@ export async function POST(request: NextRequest) {
     await supabase.auth.signOut();
 
     return NextResponse.json({
-      message: 'Kontoen din er slettet. Personopplysninger er anonymisert; fakturaer beholdes anonymt i 5 år iht. bokføringsloven.',
+      message: 'Kontoen din er slettet og innlogging er sperret. Fakturaene dine beholdes uendret i 5 år som loven krever (bokføringsloven §13), og slettes deretter.',
       data,
     });
   } catch (error) {

--- a/src/app/api/account/export/route.ts
+++ b/src/app/api/account/export/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { getAuthenticatedUser } from '@/lib/auth';
+import { createClient } from '@/utils/supabase/server';
+
+/**
+ * GET /api/account/export
+ *
+ * GDPR Art.15 data portability. Returns everything we hold about the
+ * authenticated user (profile, company settings, clients, invoices, invoice
+ * items) as a downloadable JSON attachment. The export_user_data RPC enforces
+ * that the caller can only export their own data (auth.uid() = p_user_id).
+ */
+export async function GET() {
+  try {
+    const user = await getAuthenticatedUser();
+    const supabase = await createClient();
+
+    const { data, error } = await supabase.rpc('export_user_data', { p_user_id: user.id });
+    if (error) {
+      console.error('export_user_data failed:', error);
+      return NextResponse.json({ error: 'Kunne ikke eksportere dataene dine.' }, { status: 500 });
+    }
+
+    const json = JSON.stringify(data, null, 2);
+    return new NextResponse(json, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Content-Disposition': 'attachment; filename="fakturio-data-export.json"',
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('redirect')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    console.error('Error exporting account data:', error);
+    return NextResponse.json({ error: 'Kunne ikke eksportere dataene dine.' }, { status: 500 });
+  }
+}

--- a/src/app/api/create-checkout-session/route.ts
+++ b/src/app/api/create-checkout-session/route.ts
@@ -13,7 +13,12 @@ const BUNDLE_PACKS: Record<string, { invoices: number; amount: number; label: st
   'pack_25': { invoices: 25, amount: 19900, label: '25-faktura pakke' },
 };
 
-// Subscription price IDs (set these in Stripe Dashboard)
+// Subscriptions are not a live product — Fakturio sells one-off packs only.
+// The branch below is gated behind ENABLE_SUBSCRIPTIONS so {type:'subscription'}
+// cannot reach Stripe in production (and cannot flip a profile to an "active"
+// tier that the send path would treat as unlimited). Set the env var to 'true'
+// only once a real Stripe subscription product exists.
+const SUBSCRIPTIONS_ENABLED = process.env.ENABLE_SUBSCRIPTIONS === 'true';
 const SUBSCRIPTION_PRICES: Record<string, string> = {
   starter: process.env.STRIPE_STARTER_PRICE_ID || 'price_starter',
   growth: process.env.STRIPE_GROWTH_PRICE_ID || 'price_growth',
@@ -68,8 +73,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ url: session.url });
   }
 
-  // Subscription
+  // Subscription (disabled in production — see SUBSCRIPTIONS_ENABLED above)
   if (type === 'subscription') {
+    if (!SUBSCRIPTIONS_ENABLED) {
+      return NextResponse.json({ error: 'Subscriptions are not available.' }, { status: 404 });
+    }
     const priceId = SUBSCRIPTION_PRICES[body.tier];
     if (!priceId) {
       return NextResponse.json({ error: 'Invalid tier. Use: starter, growth, enterprise' }, { status: 400 });

--- a/src/app/api/invoices/[id]/ehf/route.ts
+++ b/src/app/api/invoices/[id]/ehf/route.ts
@@ -65,6 +65,8 @@ export async function GET(
         name: company.company_name,
         org_number: company.organization_number,
         vat_number: company.vat_number,
+        vat_registered: company.vat_registered ?? false,
+        tax_exemption_reason: company.tax_exemption_reason ?? null,
         address_line1: company.address_line1,
         address_line2: company.address_line2,
         postal_code: company.postal_code,

--- a/src/app/api/invoices/[id]/route.ts
+++ b/src/app/api/invoices/[id]/route.ts
@@ -145,17 +145,63 @@ export async function PATCH(
       return NextResponse.json({ error: 'Cannot send a paid or cancelled invoice' }, { status: 400 });
     }
 
-    // Skip point deduction for unlimited subscription tiers
     const supabase = await createClient();
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('subscription_tier, subscription_status')
-      .eq('id', user.id)
+
+    // Idempotency fast-path: an already-sent invoice must not deduct a second
+    // point or re-email on a double-click or client retry.
+    if (invoice.status === 'sent') {
+      return NextResponse.json({
+        message: 'Invoice already sent',
+        data: { id: params.id, status: 'sent', alreadySent: true },
+      });
+    }
+
+    // Atomic claim: flip status to 'sent' only if it is not already 'sent'. This
+    // UPDATE is the concurrency gate — two simultaneous sends race on it and
+    // exactly one claims the row, so the point is deducted at most once. We
+    // revert to the original status below if the send cannot complete.
+    const { data: claimed } = await supabase
+      .from('invoices')
+      .update({ status: 'sent', updated_at: new Date().toISOString() })
+      .eq('id', params.id)
+      .eq('user_id', user.id)
+      .neq('status', 'sent')
+      .select('id')
       .maybeSingle();
 
-    const isUnlimited =
-      profile?.subscription_status === 'active' &&
-      (profile?.subscription_tier === 'growth' || profile?.subscription_tier === 'enterprise');
+    if (!claimed) {
+      // Lost the race — another concurrent request already claimed and sent it.
+      return NextResponse.json({
+        message: 'Invoice already sent',
+        data: { id: params.id, status: 'sent', alreadySent: true },
+      });
+    }
+
+    // Restore the pre-send status if a downstream step fails.
+    const revertClaim = async () => {
+      await supabase
+        .from('invoices')
+        .update({ status: invoice.status })
+        .eq('id', params.id)
+        .eq('user_id', user.id);
+    };
+
+    // Unlimited sends only exist for paid subscription tiers, and subscriptions
+    // are not a live product. Unless ENABLE_SUBSCRIPTIONS is explicitly on, every
+    // send deducts a point — even if a profile row was tampered to
+    // active/growth, it cannot mint free sends.
+    let isUnlimited = false;
+    if (process.env.ENABLE_SUBSCRIPTIONS === 'true') {
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('subscription_tier, subscription_status')
+        .eq('id', user.id)
+        .maybeSingle();
+
+      isUnlimited =
+        profile?.subscription_status === 'active' &&
+        (profile?.subscription_tier === 'growth' || profile?.subscription_tier === 'enterprise');
+    }
 
     if (!isUnlimited) {
       // Atomic deduct via RPC: returns null/undefined if no points to deduct.
@@ -166,10 +212,12 @@ export async function PATCH(
 
       if (rpcError) {
         console.error('Error deducting points:', rpcError);
+        await revertClaim();
         return NextResponse.json({ error: 'Failed to deduct invoice points' }, { status: 500 });
       }
 
       if (remaining === null || remaining === undefined) {
+        await revertClaim();
         return NextResponse.json({
           error: 'Insufficient invoice points. Purchase more or upgrade your plan.',
         }, { status: 402 });
@@ -204,6 +252,8 @@ export async function PATCH(
             phone: company?.phone || undefined,
             website: company?.website || undefined,
             bankAccount: company?.bank_account || undefined,
+            vatRegistered: company?.vat_registered ?? false,
+            vatNumber: company?.vat_number || undefined,
           },
           client: {
             name: fullInvoice.client.name || '',
@@ -261,6 +311,8 @@ export async function PATCH(
               name: company?.company_name,
               org_number: company?.organization_number,
               vat_number: company?.vat_number,
+              vat_registered: company?.vat_registered ?? false,
+              tax_exemption_reason: company?.tax_exemption_reason ?? null,
               address_line1: company?.address_line1,
               address_line2: company?.address_line2,
               postal_code: company?.postal_code,
@@ -308,12 +360,14 @@ export async function PATCH(
         };
       }
 
-      await updateUserRecord('invoices', params.id, { status: 'sent' });
+      // Status was already flipped to 'sent' by the atomic claim above; nothing
+      // more to do on success.
     } catch (err) {
-      // A thrown Resend error (email.ts now throws on {error}) lands here, so
-      // control never reaches the status:'sent' update at the end of the try —
-      // the invoice stays unsent and the point is refunded below.
-      console.error('Send pipeline failed, refunding point:', err);
+      // A thrown Resend error (email.ts now throws on {error}) lands here. The
+      // invoice was optimistically claimed as 'sent'; revert it and refund the
+      // point so the user can retry cleanly.
+      console.error('Send pipeline failed, reverting and refunding point:', err);
+      await revertClaim();
       if (!isUnlimited) {
         // Refund via service role (RPC is revoked from authenticated).
         await getSupabaseAdmin().rpc('add_invoice_points', { p_user_id: user.id, p_points: 1 });

--- a/src/app/api/invoices/route.ts
+++ b/src/app/api/invoices/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { fetchUserData, getAuthenticatedUser } from '@/lib/auth';
 import { createClient } from '@/utils/supabase/server';
 import { webCreateInvoiceSchema } from '@/lib/validations/invoice';
+import { computeInvoiceTotals, fromOre } from '@/lib/money';
 import type { InvoiceWithDetails } from '@/types/database';
 
 /**
@@ -61,9 +62,21 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Client not found' }, { status: 404 });
     }
 
-    const subtotalAmount = data.items.reduce((s, i) => s + i.quantity * i.unit_price, 0);
-    const vatAmount = data.items.reduce((s, i) => s + i.quantity * i.unit_price * i.vat_rate / 100, 0);
-    const totalAmount = subtotalAmount + vatAmount;
+    // A seller who is not VAT-registered must never charge MVA. We force every
+    // line to 0% here so the authoritative stored amounts never carry VAT,
+    // regardless of what the client posted. computeInvoiceTotals() does the
+    // forcing and rounds once, in øre, so DB/PDF/EHF all agree.
+    const { data: companySettings } = await supabase
+      .from('company_settings')
+      .select('vat_registered')
+      .eq('user_id', user.id)
+      .maybeSingle();
+    const sellerVatRegistered = companySettings?.vat_registered ?? false;
+
+    const totals = computeInvoiceTotals(data.items, sellerVatRegistered);
+    const subtotalAmount = fromOre(totals.subtotalOre);
+    const vatAmount = fromOre(totals.vatOre);
+    const totalAmount = fromOre(totals.totalOre);
 
     const { data: invoiceNumber, error: numErr } = await supabase.rpc('next_invoice_number', { p_user_id: user.id });
     if (numErr || !invoiceNumber) {
@@ -82,7 +95,7 @@ export async function POST(request: NextRequest) {
         notes: data.notes ?? null,
         delivery_time: data.delivery_time ?? null,
         delivery_place: data.delivery_place ?? null,
-        vat_rate: data.vat_rate,
+        vat_rate: sellerVatRegistered ? data.vat_rate : 0,
         subtotal_amount: subtotalAmount,
         vat_amount: vatAmount,
         total_amount: totalAmount,
@@ -95,14 +108,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Failed to create invoice' }, { status: 500 });
     }
 
-    const itemsPayload = data.items.map((i) => ({
+    const itemsPayload = data.items.map((i, idx) => ({
       invoice_id: invoice.id,
       description: i.description,
       quantity: i.quantity,
       unit_price: i.unit_price,
-      amount: i.quantity * i.unit_price,
-      vat_rate: i.vat_rate,
-      vat_amount: i.quantity * i.unit_price * i.vat_rate / 100,
+      amount: fromOre(totals.lines[idx].amountOre),
+      vat_rate: totals.lines[idx].effectiveRate,
+      vat_amount: fromOre(totals.lines[idx].vatAmountOre),
     }));
 
     const { error: itemsErr } = await supabase.from('invoice_items').insert(itemsPayload);

--- a/src/app/api/stripe-webhook/route.ts
+++ b/src/app/api/stripe-webhook/route.ts
@@ -141,6 +141,13 @@ export async function POST(request: Request) {
         console.log(`Added ${invoicesToAdd} invoice points for user ${userId} (pack: ${session.metadata?.pack})`);
 
       } else if (checkoutType === 'subscription') {
+        // Subscriptions are not a live product. Even if a stray subscription
+        // session somehow reaches us, refuse to flip a profile to an "active"
+        // tier — that would re-open the unlimited free-send bypass. Gated behind
+        // the same ENABLE_SUBSCRIPTIONS flag as the checkout route.
+        if (process.env.ENABLE_SUBSCRIPTIONS !== 'true') {
+          return await acknowledgeUnprocessable('Subscriptions are disabled');
+        }
         // Subscription activation — set tier
         const tier = session.metadata?.tier || 'starter';
         const { error } = await supabaseAdmin

--- a/src/app/invoices/create/page.tsx
+++ b/src/app/invoices/create/page.tsx
@@ -116,6 +116,12 @@ export default function CreateInvoicePage() {
         console.error('Error loading company settings:', error);
       } else {
         setCompanySettings(data);
+        // A non-VAT-registered seller must not charge MVA. Drive the default rate
+        // to 0 (the create route also enforces this server-side regardless).
+        if (data && data.vat_registered === false) {
+          setFormData((prev) => ({ ...prev, vat_rate: 0 }));
+          setItems((prev) => prev.map((it) => ({ ...it, vat_rate: 0, vat_amount: 0 })));
+        }
       }
     };
 
@@ -454,6 +460,11 @@ export default function CreateInvoicePage() {
                 value={formData.vat_rate}
                 onChange={(e) => setFormData({ ...formData, vat_rate: parseFloat(e.target.value) || 0 })}
               />
+              {companySettings && companySettings.vat_registered === false && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {t('Du er ikke MVA-registrert — fakturalinjer settes til 0% MVA.')}
+                </p>
+              )}
             </div>
           </div>
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from 'sonner';
-import { Save } from 'lucide-react';
+import { Save, Download, Trash2 } from 'lucide-react';
 import { t } from '@/lib/i18n';
 
 interface CompanySettings {
@@ -39,6 +39,8 @@ export default function SettingsPage() {
   const supabase = createClient();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [settings, setSettings] = useState<CompanySettings | null>(null);
   const [formData, setFormData] = useState({
     company_name: '',
@@ -167,6 +169,65 @@ export default function SettingsPage() {
       toast.error(t('Failed to save settings'));
     } finally {
       setSaving(false);
+    }
+  };
+
+  // GDPR Art.15 — download a JSON export of all the user's data.
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const res = await fetch('/api/account/export');
+      if (!res.ok) {
+        toast.error(t('Kunne ikke eksportere dataene dine.'));
+        return;
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'fakturio-data-export.json';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error('Error exporting data:', error);
+      toast.error(t('Kunne ikke eksportere dataene dine.'));
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  // GDPR Art.17 — anonymize the account. Invoices are retained anonymously for
+  // 5 years per bokføringsloven; everything else is scrubbed.
+  const handleDeleteAccount = async () => {
+    const ok = window.confirm(
+      'Er du sikker på at du vil slette kontoen din?\n\n' +
+      'Personopplysningene dine anonymiseres. Fakturaer beholdes anonymt i 5 år ' +
+      'som loven krever (bokføringsloven §13). Dette kan ikke angres.',
+    );
+    if (!ok) return;
+
+    setDeleting(true);
+    try {
+      const res = await fetch('/api/account/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm: 'SLETT' }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(data.error || t('Kunne ikke slette kontoen.'));
+        return;
+      }
+      await supabase.auth.signOut();
+      toast.success(data.message || t('Kontoen din er slettet.'));
+      router.push('/');
+    } catch (error) {
+      console.error('Error deleting account:', error);
+      toast.error(t('Kunne ikke slette kontoen.'));
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -375,6 +436,47 @@ export default function SettingsPage() {
             <Button onClick={handleSave} disabled={saving}>
               <Save className="h-4 w-4 mr-2" />
               {saving ? t('Saving...') : t('Save Settings')}
+            </Button>
+          </div>
+        </div>
+
+        {/* Personvern / GDPR */}
+        <div className="bg-card p-6 rounded-lg border space-y-6 mt-8">
+          <div>
+            <h2 className="text-xl font-semibold">{t('Personvern')}</h2>
+            <p className="text-muted-foreground text-sm">
+              {t('Last ned dataene dine eller slett kontoen din.')}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between border rounded-lg p-4">
+            <div className="max-w-xl">
+              <h3 className="font-medium">{t('Last ned mine data')}</h3>
+              <p className="text-sm text-muted-foreground">
+                {t('Få en JSON-fil med profilen, firmaopplysningene, kundene og fakturaene dine.')}
+              </p>
+            </div>
+            <Button variant="outline" onClick={handleExport} disabled={exporting} className="shrink-0">
+              <Download className="h-4 w-4 mr-2" />
+              {exporting ? t('Laster ned...') : t('Last ned mine data')}
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between border border-red-200 bg-red-50 rounded-lg p-4">
+            <div className="max-w-xl">
+              <h3 className="font-medium text-red-900">{t('Slett konto')}</h3>
+              <p className="text-sm text-red-700">
+                {t('Personopplysningene dine anonymiseres. Fakturaer beholdes anonymt i 5 år iht. bokføringsloven §13. Dette kan ikke angres.')}
+              </p>
+            </div>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteAccount}
+              disabled={deleting}
+              className="shrink-0"
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              {deleting ? t('Sletter...') : t('Slett konto')}
             </Button>
           </div>
         </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -203,8 +203,9 @@ export default function SettingsPage() {
   const handleDeleteAccount = async () => {
     const ok = window.confirm(
       'Er du sikker på at du vil slette kontoen din?\n\n' +
-      'Personopplysningene dine anonymiseres. Fakturaer beholdes anonymt i 5 år ' +
-      'som loven krever (bokføringsloven §13). Dette kan ikke angres.',
+      'Innloggingen sperres og kontoen låses. Fakturaene dine beholdes uendret i ' +
+      '5 år som loven krever (bokføringsloven §13), og slettes deretter. ' +
+      'Dette kan ikke angres.',
     );
     if (!ok) return;
 
@@ -466,7 +467,7 @@ export default function SettingsPage() {
             <div className="max-w-xl">
               <h3 className="font-medium text-red-900">{t('Slett konto')}</h3>
               <p className="text-sm text-red-700">
-                {t('Personopplysningene dine anonymiseres. Fakturaer beholdes anonymt i 5 år iht. bokføringsloven §13. Dette kan ikke angres.')}
+                {t('Innloggingen sperres og kontoen låses. Fakturaene dine beholdes uendret i 5 år iht. bokføringsloven §13, og slettes deretter. Dette kan ikke angres.')}
               </p>
             </div>
             <Button

--- a/src/components/InvoiceDetailClient.tsx
+++ b/src/components/InvoiceDetailClient.tsx
@@ -255,6 +255,8 @@ export function InvoiceDetailClient({ invoice }: InvoiceDetailClientProps) {
                         org_no: companySettings.organization_number,
                         email: companySettings.email,
                         phone: companySettings.phone,
+                        vat_registered: companySettings.vat_registered ?? false,
+                        vat_number: companySettings.vat_number ?? undefined,
                       },
                       recipient: {
                         name: invoice.client.name,
@@ -266,8 +268,14 @@ export function InvoiceDetailClient({ invoice }: InvoiceDetailClientProps) {
                         quantity: item.quantity,
                         unit: 'stk',
                         unit_price: item.unit_price,
-                        vat_rate: item.vat_rate || 25,
+                        vat_rate: item.vat_rate ?? 0,
+                        amount: item.amount,
                       })),
+                      totals: {
+                        subtotal: invoice.subtotal_amount ?? subtotalAmount,
+                        vat: invoice.vat_amount ?? totalVatAmount,
+                        total: invoice.total_amount ?? totalAmount,
+                      },
                       payment: {
                         account: companySettings.bank_account || '',
                       },

--- a/src/components/InvoicePDF.tsx
+++ b/src/components/InvoicePDF.tsx
@@ -111,10 +111,18 @@ export interface InvoicePDFProps {
     number: string;
     issue_date: string;
     due_date: string;
-    sender: { name: string; address: string; org_no: string; email: string; phone?: string };
+    sender: {
+      name: string; address: string; org_no: string; email: string; phone?: string;
+      // VAT status drives the MVA suffix and the totals label. A seller who is
+      // not registered in the Merverdiavgiftsregisteret must NOT print "MVA".
+      vat_registered: boolean; vat_number?: string;
+    };
     recipient: { name: string; company?: string; address: string; org_no?: string };
     references?: { ours?: string; theirs?: string };
-    items: Array<{ description: string; quantity: number; unit: string; unit_price: number; vat_rate: number }>;
+    // amount = precomputed line net (NOK), already rounded in øre upstream.
+    items: Array<{ description: string; quantity: number; unit: string; unit_price: number; vat_rate: number; amount: number }>;
+    // Precomputed totals (NOK) from the stored, authoritative øre values.
+    totals: { subtotal: number; vat: number; total: number };
     payment: { account: string; kid?: string; iban?: string };
     note?: string;
   };
@@ -123,10 +131,21 @@ export interface InvoicePDFProps {
 const fmt = (n: number) =>
   n.toLocaleString("nb-NO", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
+// Trim trailing ",00"/zeros from a rate so "25.00" renders as "25".
+const fmtRate = (r: number) => String(Number(r));
+
 export function InvoicePDF({ invoice: i }: InvoicePDFProps) {
-  const subtotal = i.items.reduce((s, it) => s + it.quantity * it.unit_price, 0);
-  const vat = i.items.reduce((s, it) => s + it.quantity * it.unit_price * (it.vat_rate / 100), 0);
-  const total = subtotal + vat;
+  const { subtotal, vat, total } = i.totals;
+  const vatRegistered = i.sender.vat_registered;
+
+  // Derive the MVA totals label from the actual line rates rather than a
+  // hardcoded 25%. Non-registered sellers (or a 0 VAT total) show "ikke beregnet".
+  const positiveRates = Array.from(new Set(i.items.map((it) => it.vat_rate).filter((r) => r > 0)));
+  const vatLabel = !vatRegistered || vat === 0
+    ? "MVA (ikke beregnet)"
+    : positiveRates.length === 1
+      ? `MVA ${fmtRate(positiveRates[0])}%`
+      : "MVA";
 
   return (
     <Document title={`Faktura ${i.number}`}>
@@ -142,8 +161,9 @@ export function InvoicePDF({ invoice: i }: InvoicePDFProps) {
               </View>
               <Text style={styles.senderMeta}>
                 {i.sender.name}{"\n"}{i.sender.address}{"\n"}
-                Org.nr {i.sender.org_no} MVA{"\n"}{i.sender.email}
-                {i.sender.phone ? ` · ${i.sender.phone}` : ""}
+                Org.nr {i.sender.org_no}{vatRegistered ? (i.sender.vat_number ? ` · ${i.sender.vat_number}` : " MVA") : ""}{"\n"}
+                {i.sender.email}{i.sender.phone ? ` · ${i.sender.phone}` : ""}
+                {!vatRegistered ? "\nIkke MVA-registrert. Merverdiavgift er ikke beregnet." : ""}
               </Text>
             </View>
             <View style={{ marginTop: 30 }}>
@@ -189,8 +209,8 @@ export function InvoicePDF({ invoice: i }: InvoicePDFProps) {
               <Text style={styles.cellQty}>{it.quantity}</Text>
               <Text style={styles.cellUnit}>{it.unit}</Text>
               <Text style={styles.cellPrice}>{fmt(it.unit_price)}</Text>
-              <Text style={styles.cellVat}>{it.vat_rate}%</Text>
-              <Text style={styles.cellSum}>{fmt(it.quantity * it.unit_price)}</Text>
+              <Text style={styles.cellVat}>{fmtRate(it.vat_rate)}%</Text>
+              <Text style={styles.cellSum}>{fmt(it.amount)}</Text>
             </View>
           ))}
 
@@ -201,7 +221,7 @@ export function InvoicePDF({ invoice: i }: InvoicePDFProps) {
               <Text style={{ fontFamily: "JetBrains Mono" }}>{fmt(subtotal)}</Text>
             </View>
             <View style={styles.totalsRow}>
-              <Text style={styles.totalsLabel}>MVA 25%</Text>
+              <Text style={styles.totalsLabel}>{vatLabel}</Text>
               <Text style={{ fontFamily: "JetBrains Mono" }}>{fmt(vat)}</Text>
             </View>
             <View style={styles.totalsFinal}>

--- a/src/lib/ehf.ts
+++ b/src/lib/ehf.ts
@@ -8,16 +8,26 @@
  * everything is escaped through `xe()` before interpolation.
  */
 
+import { computeInvoiceTotals } from './money';
+
 const CUSTOMIZATION_ID = 'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0';
 const PROFILE_ID = 'urn:fdc:peppol.eu:2017:poacc:billing:01:1.0';
 const INVOICE_TYPE_COMMERCIAL = '380';
 const PAYMENT_MEANS_CREDIT_TRANSFER = '30';
 const PEPPOL_SCHEME_NO_ORG = '0192'; // Norwegian Organisation Number
 
+// EN16931 category 'E' (exempt) requires a human-readable exemption reason
+// (BT-120). Default text for a Norwegian seller below the MVA threshold.
+const DEFAULT_TAX_EXEMPTION_REASON = 'Selger er ikke registrert i Merverdiavgiftsregisteret';
+
 export interface EhfCompany {
   name: string;
   org_number?: string | null;
   vat_number?: string | null;       // e.g. "NO999888777MVA"
+  // True only when registered in the Merverdiavgiftsregisteret. Drives whether
+  // lines use category 'S' (with a seller VAT id) or 'E' (exempt, no VAT id).
+  vat_registered?: boolean | null;
+  tax_exemption_reason?: string | null; // BT-120 text used for category 'E'
   address_line1?: string | null;
   address_line2?: string | null;
   postal_code?: string | null;
@@ -99,10 +109,18 @@ function peppolEndpoint(endpoint: string | null | undefined, orgNumber: string |
   return null;
 }
 
-/** Returns the EN16931 tax category code for a given rate. */
-function taxCategory(rate: number): 'S' | 'Z' | 'E' {
+/**
+ * Returns the EN16931 tax category code for a line.
+ *
+ * A seller NOT registered for VAT must use 'E' (exempt) — BR-S-02 forbids
+ * category 'S' unless the seller carries a VAT identifier, which a
+ * non-registered seller does not have. A registered seller uses 'S' for
+ * positive rates and 'Z' (zero-rated) for an explicit 0% line.
+ */
+function taxCategory(rate: number, sellerVatRegistered: boolean): 'S' | 'Z' | 'E' {
+  if (!sellerVatRegistered) return 'E';
   if (rate > 0) return 'S';
-  return 'Z'; // zero-rated; "E" (exempt) requires a tax exemption reason
+  return 'Z';
 }
 
 function validate(invoice: EhfInvoice, company: EhfCompany, client: EhfClient): void {
@@ -113,6 +131,8 @@ function validate(invoice: EhfInvoice, company: EhfCompany, client: EhfClient): 
   if (!company.city) missing.push('company.city');
   if (!company.postal_code) missing.push('company.postal_code');
   if (!company.bank_account) missing.push('company.bank_account');
+  // A VAT-registered seller emitting category 'S' MUST carry a VAT id (BR-S-02).
+  if (company.vat_registered && !company.vat_number) missing.push('company.vat_number');
   if (!client.name) missing.push('client.name');
   if (!client.org_number) missing.push('client.org_number');
   if (!client.address_line1) missing.push('client.address_line1');
@@ -188,31 +208,44 @@ export function buildEhfInvoice(input: {
   validate(invoice, company, client);
 
   const currency = (invoice.currency || 'NOK').toUpperCase();
+  const sellerVatRegistered = !!company.vat_registered;
+  const exemptionReason = company.tax_exemption_reason || DEFAULT_TAX_EXEMPTION_REASON;
 
-  // Per-line totals.
-  type Computed = EhfLine & { line_amount: number; tax_amount: number; line_no: number };
-  const computed: Computed[] = invoice.lines.map((l, i) => {
-    const line_amount = l.quantity * l.unit_price;
-    return {
-      ...l,
-      line_amount,
-      tax_amount: line_amount * (l.vat_rate / 100),
-      line_no: i + 1,
-    };
-  });
+  // Single rounding pass in integer øre, shared with the DB and PDF so all three
+  // agree exactly (sum of line tax === document tax, satisfying EN16931 rounding).
+  const totals = computeInvoiceTotals(
+    invoice.lines.map((l) => ({ quantity: l.quantity, unit_price: l.unit_price, vat_rate: l.vat_rate })),
+    sellerVatRegistered,
+  );
+  const oreStr = (ore: number) => (ore / 100).toFixed(2);
 
-  const lineTotal = computed.reduce((s, l) => s + l.line_amount, 0);
-  const taxTotal = computed.reduce((s, l) => s + l.tax_amount, 0);
-  const payable = lineTotal + taxTotal;
+  type Computed = EhfLine & {
+    line_no: number;
+    cat: 'S' | 'Z' | 'E';
+    effectiveRate: number;
+    amountOre: number;
+    taxOre: number;
+  };
+  const computed: Computed[] = invoice.lines.map((l, i) => ({
+    ...l,
+    line_no: i + 1,
+    cat: taxCategory(l.vat_rate, sellerVatRegistered),
+    effectiveRate: totals.lines[i].effectiveRate,
+    amountOre: totals.lines[i].amountOre,
+    taxOre: totals.lines[i].vatAmountOre,
+  }));
 
-  // Group by (rate, category) for cac:TaxSubtotal.
-  const groups = new Map<string, { rate: number; cat: string; taxable: number; tax: number }>();
+  const lineTotalOre = totals.subtotalOre;
+  const taxTotalOre = totals.vatOre;
+  const payableOre = totals.totalOre;
+
+  // Group by (category, effective rate) for cac:TaxSubtotal.
+  const groups = new Map<string, { rate: number; cat: 'S' | 'Z' | 'E'; taxableOre: number; taxOre: number }>();
   for (const l of computed) {
-    const cat = taxCategory(l.vat_rate);
-    const key = `${cat}:${l.vat_rate}`;
-    const g = groups.get(key) ?? { rate: l.vat_rate, cat, taxable: 0, tax: 0 };
-    g.taxable += l.line_amount;
-    g.tax += l.tax_amount;
+    const key = `${l.cat}:${l.effectiveRate}`;
+    const g = groups.get(key) ?? { rate: l.effectiveRate, cat: l.cat, taxableOre: 0, taxOre: 0 };
+    g.taxableOre += l.amountOre;
+    g.taxOre += l.taxOre;
     groups.set(key, g);
   }
 
@@ -224,7 +257,9 @@ export function buildEhfInvoice(input: {
     legalName: company.name,
     partyName: company.name,
     orgNumber: company.org_number,
-    vatNumber: company.vat_number,
+    // Only a genuinely VAT-registered seller emits a VAT id. A non-registered
+    // seller must NOT (category 'E' + no PartyTaxScheme avoids BR-S-02).
+    vatNumber: sellerVatRegistered ? company.vat_number : null,
     address1: company.address_line1,
     address2: company.address_line2,
     postal: company.postal_code,
@@ -251,27 +286,34 @@ export function buildEhfInvoice(input: {
     email: client.email,
   });
 
-  const subtotalXml = Array.from(groups.values()).map((g) => `
+  const subtotalXml = Array.from(groups.values()).map((g) => {
+    // EN16931 element order inside cac:TaxCategory: ID, Percent,
+    // TaxExemptionReason, TaxScheme. Reason is required for category 'E'.
+    const exemptionXml = g.cat === 'E'
+      ? `\n        <cbc:TaxExemptionReason>${xe(exemptionReason)}</cbc:TaxExemptionReason>`
+      : '';
+    return `
     <cac:TaxSubtotal>
-      <cbc:TaxableAmount currencyID="${currency}">${n2(g.taxable)}</cbc:TaxableAmount>
-      <cbc:TaxAmount currencyID="${currency}">${n2(g.tax)}</cbc:TaxAmount>
+      <cbc:TaxableAmount currencyID="${currency}">${oreStr(g.taxableOre)}</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="${currency}">${oreStr(g.taxOre)}</cbc:TaxAmount>
       <cac:TaxCategory>
         <cbc:ID>${g.cat}</cbc:ID>
-        <cbc:Percent>${n2(g.rate)}</cbc:Percent>
+        <cbc:Percent>${n2(g.rate)}</cbc:Percent>${exemptionXml}
         <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
       </cac:TaxCategory>
-    </cac:TaxSubtotal>`).join('');
+    </cac:TaxSubtotal>`;
+  }).join('');
 
   const linesXml = computed.map((l) => `
   <cac:InvoiceLine>
     <cbc:ID>${l.line_no}</cbc:ID>
     <cbc:InvoicedQuantity unitCode="${xe(l.unit_code || 'C62')}">${n2(l.quantity)}</cbc:InvoicedQuantity>
-    <cbc:LineExtensionAmount currencyID="${currency}">${n2(l.line_amount)}</cbc:LineExtensionAmount>
+    <cbc:LineExtensionAmount currencyID="${currency}">${oreStr(l.amountOre)}</cbc:LineExtensionAmount>
     <cac:Item>
       <cbc:Name>${xe(l.description)}</cbc:Name>
       <cac:ClassifiedTaxCategory>
-        <cbc:ID>${taxCategory(l.vat_rate)}</cbc:ID>
-        <cbc:Percent>${n2(l.vat_rate)}</cbc:Percent>
+        <cbc:ID>${l.cat}</cbc:ID>
+        <cbc:Percent>${n2(l.effectiveRate)}</cbc:Percent>
         <cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>
       </cac:ClassifiedTaxCategory>
     </cac:Item>
@@ -309,13 +351,13 @@ export function buildEhfInvoice(input: {
     </cac:PayeeFinancialAccount>
   </cac:PaymentMeans>
   <cac:TaxTotal>
-    <cbc:TaxAmount currencyID="${currency}">${n2(taxTotal)}</cbc:TaxAmount>${subtotalXml}
+    <cbc:TaxAmount currencyID="${currency}">${oreStr(taxTotalOre)}</cbc:TaxAmount>${subtotalXml}
   </cac:TaxTotal>
   <cac:LegalMonetaryTotal>
-    <cbc:LineExtensionAmount currencyID="${currency}">${n2(lineTotal)}</cbc:LineExtensionAmount>
-    <cbc:TaxExclusiveAmount currencyID="${currency}">${n2(lineTotal)}</cbc:TaxExclusiveAmount>
-    <cbc:TaxInclusiveAmount currencyID="${currency}">${n2(payable)}</cbc:TaxInclusiveAmount>
-    <cbc:PayableAmount currencyID="${currency}">${n2(payable)}</cbc:PayableAmount>
+    <cbc:LineExtensionAmount currencyID="${currency}">${oreStr(lineTotalOre)}</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="${currency}">${oreStr(lineTotalOre)}</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="${currency}">${oreStr(payableOre)}</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="${currency}">${oreStr(payableOre)}</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>${linesXml}
 </Invoice>
 `;

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -1,0 +1,78 @@
+/**
+ * Single source of truth for invoice money math.
+ *
+ * Money is NOK, handled in integer øre. The DB, the PDF, and the EHF XML must
+ * all agree to the øre — previously each recomputed totals independently with
+ * float arithmetic, which could disagree by an øre and break EN16931 rounding
+ * rules (sum of line tax must equal the document tax). Every consumer now calls
+ * computeInvoiceTotals() so rounding happens once, per line, in øre.
+ *
+ * VAT registration is enforced here too: a seller who is NOT registered in the
+ * Merverdiavgiftsregisteret must never carry VAT. When sellerVatRegistered is
+ * false, every line's effective rate is forced to 0.
+ */
+
+export interface MoneyLineInput {
+  quantity: number;
+  unit_price: number; // NOK
+  vat_rate: number;   // percent, e.g. 25
+}
+
+export interface MoneyLineResult {
+  /** Effective VAT rate after applying seller registration (0 if not registered). */
+  effectiveRate: number;
+  /** Line net amount (quantity × unit_price), rounded, in øre. */
+  amountOre: number;
+  /** Line VAT amount, rounded, in øre. */
+  vatAmountOre: number;
+}
+
+export interface InvoiceTotals {
+  lines: MoneyLineResult[];
+  subtotalOre: number;
+  vatOre: number;
+  totalOre: number;
+}
+
+/** NOK → integer øre. */
+export function toOre(nok: number): number {
+  return Math.round(nok * 100);
+}
+
+/** Integer øre → NOK (number). */
+export function fromOre(ore: number): number {
+  return ore / 100;
+}
+
+/**
+ * Compute all invoice totals once, in øre, rounding per line.
+ *
+ * @param items               line inputs (quantity, unit_price NOK, vat_rate %)
+ * @param sellerVatRegistered when false, every line's VAT is forced to 0
+ */
+export function computeInvoiceTotals(
+  items: MoneyLineInput[],
+  sellerVatRegistered: boolean,
+): InvoiceTotals {
+  const lines: MoneyLineResult[] = items.map((it) => {
+    const effectiveRate = sellerVatRegistered ? it.vat_rate : 0;
+    // quantity is an integer count; round the unit price to øre first, then
+    // multiply, so each line is exact to the øre.
+    const amountOre = Math.round(toOre(it.unit_price) * it.quantity);
+    const vatAmountOre = Math.round((amountOre * effectiveRate) / 100);
+    return { effectiveRate, amountOre, vatAmountOre };
+  });
+
+  const subtotalOre = lines.reduce((s, l) => s + l.amountOre, 0);
+  const vatOre = lines.reduce((s, l) => s + l.vatAmountOre, 0);
+
+  return { lines, subtotalOre, vatOre, totalOre: subtotalOre + vatOre };
+}
+
+/** Format an øre amount as a Norwegian-locale 2-decimal string (no currency). */
+export function formatOre(ore: number): string {
+  return fromOre(ore).toLocaleString('nb-NO', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}

--- a/src/lib/pdf.ts
+++ b/src/lib/pdf.ts
@@ -26,6 +26,8 @@ export interface LegacyInvoicePDFData {
     logoUrl?: string;
     slogan?: string;
     bankAccount?: string;
+    vatRegistered?: boolean;
+    vatNumber?: string;
   };
   client: {
     name: string;
@@ -69,6 +71,8 @@ export function adaptLegacyInvoicePdfData(d: LegacyInvoicePDFData): InvoicePDFPr
         org_no: d.company.orgNumber,
         email: d.company.email,
         phone: d.company.phone,
+        vat_registered: d.company.vatRegistered ?? false,
+        vat_number: d.company.vatNumber,
       },
       recipient: {
         name: d.client.name,
@@ -83,7 +87,13 @@ export function adaptLegacyInvoicePdfData(d: LegacyInvoicePDFData): InvoicePDFPr
         unit: it.unit,
         unit_price: it.unitPrice,
         vat_rate: it.vat,
+        amount: it.amount,
       })),
+      totals: {
+        subtotal: d.invoice.subtotal,
+        vat: d.invoice.vat,
+        total: d.invoice.total,
+      },
       payment: {
         account: d.company.bankAccount ?? "",
       },

--- a/src/lib/validations/invoice.ts
+++ b/src/lib/validations/invoice.ts
@@ -27,7 +27,10 @@ export const updateInvoiceSchema = z.object({
   vat_rate: z.number().min(0).max(100).optional(),
 });
 
-// Web-app invoice creation: client_id (existing client) + line items
+// Web-app invoice creation: client_id (existing client) + line items.
+// NOTE: vat_rate defaults to 25 here, but the create route (api/invoices) forces
+// every line's rate to 0 server-side when the seller's company_settings.
+// vat_registered is false, so a non-registered seller can never store MVA.
 export const webCreateInvoiceSchema = z.object({
   client_id: z.string().uuid(),
   issue_date: z.string(),

--- a/supabase/migrations/20260605120000_tax_exemption_and_gdpr.sql
+++ b/supabase/migrations/20260605120000_tax_exemption_and_gdpr.sql
@@ -4,10 +4,17 @@
 --    'E' lines for sellers below the MVA threshold.
 -- 2. profiles.deleted_at / anonymized_at — account-erasure markers.
 -- 3. export_user_data()      — GDPR Art.15 data portability.
--- 4. anonymize_user_account() — GDPR Art.17 erasure that ANONYMIZES retained
---    invoices rather than deleting them (bokføringsloven §13 requires ~5-year
---    retention; Art.17(3)(b) lets the retention obligation override erasure for
---    the data needed to satisfy it).
+-- 4. anonymize_user_account() — GDPR Art.17 erasure. Bokføringsloven §13 +
+--    bokføringsforskriften require sales documents to be retained COMPLETE and
+--    UNALTERED for ~5 years; mutating a stored accounting record (or stripping
+--    the buyer identity it must carry) would itself breach that. Art.17(3)(b)
+--    exempts data held under a legal retention obligation from erasure, so we do
+--    NOT touch clients or invoices here. We "lock" the account: ban login (done
+--    by the API route), mark the profile erased, and scrub only the seller's own
+--    contact fields that the invoice does not legally require (email, phone,
+--    website, notes). The seller's legal identity on retained invoices
+--    (company_name, organization_number, address, vat_number, bank_account) is
+--    kept. A separate post-retention purge job (Phase 6) hard-deletes after 5y.
 --
 -- Both RPCs are SECURITY DEFINER but verify auth.uid() = p_user_id internally,
 -- pin search_path, and follow the secure_invoice_share (20260510120000) ACL
@@ -75,7 +82,7 @@ revoke all on function public.export_user_data(uuid) from public;
 grant execute on function public.export_user_data(uuid) to authenticated;
 
 -- ----------------------------------------------------------------------------
--- 4. GDPR Art.17 — erase by anonymization (retained invoices kept)
+-- 4. GDPR Art.17 — lock the account; retain the books unaltered
 -- ----------------------------------------------------------------------------
 create or replace function public.anonymize_user_account(p_user_id uuid)
 returns jsonb
@@ -85,61 +92,32 @@ set search_path = public
 as $$
 declare
   v_uid uuid := auth.uid();
-  v_clients integer;
   v_invoices integer;
 begin
   if v_uid is null or v_uid <> p_user_id then
     raise exception 'not authorized';
   end if;
 
-  -- Clients are not a retained accounting document: scrub all PII and
-  -- soft-delete them.
-  update public.clients
-     set name           = 'Anonymisert',
-         email          = 'anonymisert@example.invalid',
-         phone          = null,
-         company        = null,
-         org_number     = null,
-         vat_number     = null,
-         address_line1  = null,
-         address_line2  = null,
-         postal_code    = null,
-         city           = null,
-         peppol_endpoint = null,
-         deleted_at     = coalesce(deleted_at, now()),
-         updated_at     = now()
-   where user_id = p_user_id::text;
-  get diagnostics v_clients = row_count;
+  -- Clients and invoices are NOT touched: they are part of the retained
+  -- accounting record (bokføringsloven §13) and must stay complete and
+  -- unaltered. Art.17(3)(b) exempts them from erasure until the retention period
+  -- expires, after which a separate purge job removes them.
+  select count(*) into v_invoices from public.invoices where user_id = p_user_id::text;
 
-  -- Invoices MUST be retained (bokføringsloven §13), so we anonymize instead of
-  -- deleting: financial fields (amounts, dates, invoice_number) are kept, while
-  -- free-text fields that may carry personal data are cleared. The buyer's
-  -- identity is already anonymized via the clients FK above.
-  update public.invoices
-     set notes             = null,
-         delivery_place    = null,
-         buyer_reference   = null,
-         payment_reference = null,
-         updated_at        = now()
-   where user_id = p_user_id::text;
-  get diagnostics v_invoices = row_count;
-
-  -- Company settings: scrub the seller's contact PII. The legally-required
-  -- seller identification on retained invoices (company_name, organization_
-  -- number, address) is preserved per GDPR Art.17(3)(b).
+  -- Scrub only the seller's own contact fields that the invoice does not legally
+  -- require. Legal seller identity (company_name, organization_number, address,
+  -- vat_number, bank_account) is kept so retained invoices remain valid.
   update public.company_settings
-     set email        = 'anonymisert@example.invalid',
-         phone        = null,
-         website      = null,
-         bank_account = null,
-         vat_number   = null,
-         notes        = null,
-         updated_at   = now()
+     set email      = 'anonymisert@example.invalid',
+         phone      = null,
+         website    = null,
+         notes      = null,
+         updated_at = now()
    where user_id = p_user_id;
 
-  -- Mark the profile erased. The auth.users row itself is banned (not deleted)
-  -- by the API route, because profiles/company_settings cascade from it and must
-  -- survive for invoice retention.
+  -- Mark the profile erased (the "lock"). The auth.users row is banned (not
+  -- deleted) by the API route, because profiles/company_settings cascade from it
+  -- and must survive for invoice retention.
   update public.profiles
      set anonymized_at = now(),
          deleted_at    = now(),
@@ -147,10 +125,10 @@ begin
    where id = p_user_id;
 
   insert into public.audit_log (user_id, action, resource_type, resource_id, details)
-  values (p_user_id, 'account.anonymize', 'profile', p_user_id,
-          jsonb_build_object('clients_scrubbed', v_clients, 'invoices_retained', v_invoices));
+  values (p_user_id, 'account.erase_lock', 'profile', p_user_id,
+          jsonb_build_object('invoices_retained', v_invoices));
 
-  return jsonb_build_object('ok', true, 'clients_scrubbed', v_clients, 'invoices_retained', v_invoices);
+  return jsonb_build_object('ok', true, 'invoices_retained', v_invoices);
 end;
 $$;
 

--- a/supabase/migrations/20260605120000_tax_exemption_and_gdpr.sql
+++ b/supabase/migrations/20260605120000_tax_exemption_and_gdpr.sql
@@ -1,0 +1,158 @@
+-- Phase 5: tax exemption reason + GDPR export/erasure.
+--
+-- 1. company_settings.tax_exemption_reason — BT-120 text emitted on EHF category
+--    'E' lines for sellers below the MVA threshold.
+-- 2. profiles.deleted_at / anonymized_at — account-erasure markers.
+-- 3. export_user_data()      — GDPR Art.15 data portability.
+-- 4. anonymize_user_account() — GDPR Art.17 erasure that ANONYMIZES retained
+--    invoices rather than deleting them (bokføringsloven §13 requires ~5-year
+--    retention; Art.17(3)(b) lets the retention obligation override erasure for
+--    the data needed to satisfy it).
+--
+-- Both RPCs are SECURITY DEFINER but verify auth.uid() = p_user_id internally,
+-- pin search_path, and follow the secure_invoice_share (20260510120000) ACL
+-- pattern: revoke all from public, grant execute to authenticated only (never
+-- anon — these are authed-only actions).
+--
+-- NOTE on user_id types: clients.user_id and invoices.user_id are TEXT (they
+-- store the uuid as text); company_settings.user_id and profiles.id are UUID.
+-- Hence the ::text casts on clients/invoices below.
+
+-- ----------------------------------------------------------------------------
+-- 1. Tax exemption reason
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.company_settings
+  ADD COLUMN IF NOT EXISTS tax_exemption_reason text
+    DEFAULT 'Selger er ikke registrert i Merverdiavgiftsregisteret';
+
+COMMENT ON COLUMN public.company_settings.tax_exemption_reason IS
+  'EN16931 BT-120 exemption reason emitted on EHF category E lines (non-VAT-registered seller).';
+
+-- ----------------------------------------------------------------------------
+-- 2. Account erasure markers
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS deleted_at    timestamptz,
+  ADD COLUMN IF NOT EXISTS anonymized_at timestamptz;
+
+-- ----------------------------------------------------------------------------
+-- 3. GDPR Art.15 — export everything we hold about the caller
+-- ----------------------------------------------------------------------------
+create or replace function public.export_user_data(p_user_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+begin
+  if v_uid is null or v_uid <> p_user_id then
+    raise exception 'not authorized';
+  end if;
+
+  return jsonb_build_object(
+    'exported_at', now(),
+    'profile', (select to_jsonb(p) from public.profiles p where p.id = p_user_id),
+    'company_settings', (select to_jsonb(cs) from public.company_settings cs where cs.user_id = p_user_id),
+    'clients', coalesce(
+      (select jsonb_agg(to_jsonb(c) order by c.created_at)
+         from public.clients c where c.user_id = p_user_id::text), '[]'::jsonb),
+    'invoices', coalesce(
+      (select jsonb_agg(to_jsonb(i) order by i.created_at)
+         from public.invoices i where i.user_id = p_user_id::text), '[]'::jsonb),
+    'invoice_items', coalesce(
+      (select jsonb_agg(to_jsonb(ii))
+         from public.invoice_items ii
+        where ii.invoice_id in (select id from public.invoices where user_id = p_user_id::text)),
+      '[]'::jsonb)
+  );
+end;
+$$;
+
+revoke all on function public.export_user_data(uuid) from public;
+grant execute on function public.export_user_data(uuid) to authenticated;
+
+-- ----------------------------------------------------------------------------
+-- 4. GDPR Art.17 — erase by anonymization (retained invoices kept)
+-- ----------------------------------------------------------------------------
+create or replace function public.anonymize_user_account(p_user_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_clients integer;
+  v_invoices integer;
+begin
+  if v_uid is null or v_uid <> p_user_id then
+    raise exception 'not authorized';
+  end if;
+
+  -- Clients are not a retained accounting document: scrub all PII and
+  -- soft-delete them.
+  update public.clients
+     set name           = 'Anonymisert',
+         email          = 'anonymisert@example.invalid',
+         phone          = null,
+         company        = null,
+         org_number     = null,
+         vat_number     = null,
+         address_line1  = null,
+         address_line2  = null,
+         postal_code    = null,
+         city           = null,
+         peppol_endpoint = null,
+         deleted_at     = coalesce(deleted_at, now()),
+         updated_at     = now()
+   where user_id = p_user_id::text;
+  get diagnostics v_clients = row_count;
+
+  -- Invoices MUST be retained (bokføringsloven §13), so we anonymize instead of
+  -- deleting: financial fields (amounts, dates, invoice_number) are kept, while
+  -- free-text fields that may carry personal data are cleared. The buyer's
+  -- identity is already anonymized via the clients FK above.
+  update public.invoices
+     set notes             = null,
+         delivery_place    = null,
+         buyer_reference   = null,
+         payment_reference = null,
+         updated_at        = now()
+   where user_id = p_user_id::text;
+  get diagnostics v_invoices = row_count;
+
+  -- Company settings: scrub the seller's contact PII. The legally-required
+  -- seller identification on retained invoices (company_name, organization_
+  -- number, address) is preserved per GDPR Art.17(3)(b).
+  update public.company_settings
+     set email        = 'anonymisert@example.invalid',
+         phone        = null,
+         website      = null,
+         bank_account = null,
+         vat_number   = null,
+         notes        = null,
+         updated_at   = now()
+   where user_id = p_user_id;
+
+  -- Mark the profile erased. The auth.users row itself is banned (not deleted)
+  -- by the API route, because profiles/company_settings cascade from it and must
+  -- survive for invoice retention.
+  update public.profiles
+     set anonymized_at = now(),
+         deleted_at    = now(),
+         updated_at    = now()
+   where id = p_user_id;
+
+  insert into public.audit_log (user_id, action, resource_type, resource_id, details)
+  values (p_user_id, 'account.anonymize', 'profile', p_user_id,
+          jsonb_build_object('clients_scrubbed', v_clients, 'invoices_retained', v_invoices));
+
+  return jsonb_build_object('ok', true, 'clients_scrubbed', v_clients, 'invoices_retained', v_invoices);
+end;
+$$;
+
+revoke all on function public.anonymize_user_account(uuid) from public;
+grant execute on function public.anonymize_user_account(uuid) to authenticated;


### PR DESCRIPTION
Phase 5 of the go-live plan (`docs/golive/phase-5-high-correctness.md`). Six HIGH-tier correctness fixes before charging real money.

## What's in it
- **VAT/MVA legality** — non-registered sellers no longer print "MVA" on the PDF or a hardcoded "MVA 25%" totals label; the create route forces every line to 0% server-side based on `company_settings.vat_registered`.
- **EHF BR-S-02** — `taxCategory` returns `E` (exempt) with a `TaxExemptionReason` and no seller `PartyTaxScheme` for non-registered sellers; `S` only with a `vat_number`. `validate()` requires `vat_number` when registered.
- **Dead subscription path** — checkout + webhook activation gated behind `ENABLE_SUBSCRIPTIONS` (unset = off); unlimited point-bypass neutralized so every send deducts a point.
- **Send idempotency** — early-return on already-sent + atomic conditional status claim before deduct/email; failures revert + refund.
- **Money in øre** — new `src/lib/money.ts` computes totals once in integer øre, shared by DB/PDF/EHF so `sum(line tax) == document tax` exactly.
- **GDPR** — `export_user_data` (Art.15) + `anonymize_user_account` (Art.17) RPCs, `/api/account/export` + `/delete` routes, Personvern section in settings. Deletion **locks** the account (bans login, marks profile erased, scrubs only the seller's non-required contact fields) and leaves clients + invoices **unaltered** for bokføringsloven §13 retention; a post-5-year purge is deferred to Phase 6.

Also configures eslint (`.eslintrc.json` → `next/core-web-vitals`).

## Migration
`supabase/migrations/20260605120000_tax_exemption_and_gdpr.sql` is applied automatically by the deploy workflow (`supabase db push` runs before app deploy on merge to `main`).

## Verification done
- `tsc --noEmit` clean; `next lint` (warnings only, all pre-existing).
- Runtime check: non-registered EHF = category `E` + exemption reason + no `PartyTaxScheme` + tax 0.00; registered = `S` + `PartyTaxScheme`; money parity (`docTax == sum(subtotalTax)`) holds in both.

## Verify before/after merge
- Run a downloaded EHF for a non-VAT-registered seller through an EN16931/PEPPOL validator (expect zero BR-S errors).
- Double-fire Send (expect exactly one point deducted, one email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)