### PR TITLE
Products overview + invoice-line prefill

### DIFF
--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchUserRecord, updateUserRecord, deleteUserRecord } from '@/lib/auth';
+import { createProductSchema } from '@/lib/validations/invoice';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const product = await fetchUserRecord('products', params.id, '*');
+    if (!product) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ data: product });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('redirect')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to fetch product' }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const body = await request.json().catch(() => null);
+    if (!body) return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+
+    const result = createProductSchema.partial().safeParse(body);
+    if (!result.success) {
+      return NextResponse.json({
+        error: 'Validation failed',
+        details: result.error.flatten().fieldErrors,
+      }, { status: 400 });
+    }
+
+    await updateUserRecord('products', params.id, result.data);
+    return NextResponse.json({ message: 'Product updated', data: { id: params.id, ...result.data } });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('redirect')) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      if (error.message.includes('Unauthorized')) return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
+    return NextResponse.json({ error: 'Failed to update product' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    await deleteUserRecord('products', params.id);
+    return NextResponse.json({ message: 'Product deleted' });
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.message.includes('redirect')) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      if (error.message.includes('Unauthorized')) return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
+    return NextResponse.json({ error: 'Failed to delete product' }, { status: 500 });
+  }
+}

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchUserData, getAuthenticatedUser } from '@/lib/auth';
+import { createClient } from '@/utils/supabase/server';
+import { createProductSchema } from '@/lib/validations/invoice';
+
+/**
+ * GET /api/products — List the authed user's products
+ */
+export async function GET() {
+  try {
+    const products = await fetchUserData('products', '*', { deleted_at: null });
+    return NextResponse.json({ data: products });
+  } catch (error) {
+    console.error('Error fetching products:', error);
+    if (error instanceof Error && error.message.includes('redirect')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to fetch products' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/products — Create a product
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getAuthenticatedUser();
+    const body = await request.json().catch(() => null);
+    if (!body) return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+
+    const result = createProductSchema.safeParse(body);
+    if (!result.success) {
+      return NextResponse.json({
+        error: 'Validation failed',
+        details: result.error.flatten().fieldErrors,
+      }, { status: 400 });
+    }
+
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('products')
+      .insert({ user_id: user.id, ...result.data })
+      .select('*')
+      .single();
+
+    if (error) {
+      console.error('Product insert failed:', error);
+      return NextResponse.json({ error: 'Failed to create product' }, { status: 500 });
+    }
+
+    return NextResponse.json({ data }, { status: 201 });
+  } catch (error) {
+    console.error('Error creating product:', error);
+    if (error instanceof Error && error.message.includes('redirect')) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Failed to create product' }, { status: 500 });
+  }
+}

--- a/src/app/invoices/create/page.tsx
+++ b/src/app/invoices/create/page.tsx
@@ -10,7 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import Link from 'next/link';
 import { Plus, Trash2, Save, Send, Coins, AlertCircle } from 'lucide-react';
 import { toast } from 'sonner';
-import type { Client, InvoiceStatus, Profile } from '@/types/database';
+import type { Client, InvoiceStatus, Profile, Product } from '@/types/database';
 import { t } from '@/lib/i18n';
 import { Wordmark } from '@/components/brand/Wordmark';
 import { ChecksCard } from '@/components/invoices/ChecksCard';
@@ -33,6 +33,7 @@ export default function CreateInvoicePage() {
   const supabase = createClient();
 
   const [clients, setClients] = useState<Client[]>([]);
+  const [products, setProducts] = useState<Product[]>([]);
   const [companySettings, setCompanySettings] = useState<any>(null);
   const [formData, setFormData] = useState({
     client_id: '',
@@ -101,6 +102,28 @@ export default function CreateInvoicePage() {
     loadClients();
   }, [user, supabase]);
 
+  // Load products for the per-line product picker
+  useEffect(() => {
+    const loadProducts = async () => {
+      if (!user) return;
+
+      const { data, error } = await supabase
+        .from('products')
+        .select('*')
+        .eq('user_id', user.id)
+        .is('deleted_at', null)
+        .order('name');
+
+      if (error) {
+        console.error('Error loading products:', error);
+      } else {
+        setProducts(data || []);
+      }
+    };
+
+    loadProducts();
+  }, [user, supabase]);
+
   // Load company settings
   useEffect(() => {
     const loadCompanySettings = async () => {
@@ -140,6 +163,27 @@ export default function CreateInvoicePage() {
       newItems[index].vat_amount = subtotal * (newItems[index].vat_rate / 100);
     }
     
+    setItems(newItems);
+  };
+
+  // Prefill a line from a saved product (description / price / VAT / unit).
+  const applyProduct = (index: number, productId: string) => {
+    const p = products.find((x) => x.id === productId);
+    if (!p) return;
+    // Respect the seller's VAT status: a non-registered seller's lines stay 0%.
+    const sellerRegistered = companySettings?.vat_registered !== false;
+    const vat_rate = sellerRegistered ? (Number(p.vat_rate) || 0) : 0;
+    const unit_price = Number(p.unit_price) || 0;
+    const newItems = [...items];
+    const subtotal = newItems[index].quantity * unit_price;
+    newItems[index] = {
+      ...newItems[index],
+      description: (p.description && p.description.trim()) || p.name,
+      unit_price,
+      vat_rate,
+      amount: subtotal,
+      vat_amount: subtotal * (vat_rate / 100),
+    };
     setItems(newItems);
   };
 
@@ -496,6 +540,21 @@ export default function CreateInvoicePage() {
               <div key={index} className="grid grid-cols-12 gap-4 items-end">
                 <div className="col-span-4">
                   <Label>{t('Description')} *</Label>
+                  {products.length > 0 && (
+                    <Select value="" onValueChange={(v) => applyProduct(index, v)}>
+                      <SelectTrigger className="mb-2">
+                        <SelectValue placeholder={t('Velg produkt (valgfri)')} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {products.map((p) => (
+                          <SelectItem key={p.id} value={p.id}>
+                            {p.name}
+                            {p.product_number ? ` · ${p.product_number}` : ''} · {Number(p.unit_price).toFixed(2)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
                   <Input
                     placeholder={t('Item description')}
                     value={item.description}

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/utils/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import type { Product } from '@/types/database';
+import { ArrowLeft, Save, Trash } from 'lucide-react';
+import Link from 'next/link';
+import { t } from '@/lib/i18n';
+
+export default function ProductDetailPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+  const supabase = createClient();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [product, setProduct] = useState<Product | null>(null);
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    unit_price: 0,
+    vat_rate: 25,
+    unit: 'stk',
+    product_number: '',
+  });
+
+  useEffect(() => {
+    const fetchProduct = async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) {
+          toast.error(t('You must be logged in to view products'));
+          router.push('/sign-in');
+          return;
+        }
+
+        const { data, error } = await supabase
+          .from('products')
+          .select('*')
+          .eq('id', params.id)
+          .single();
+
+        if (error) throw error;
+        if (!data) {
+          toast.error(t('Product not found'));
+          router.push('/products');
+          return;
+        }
+
+        setProduct(data);
+        setFormData({
+          name: data.name,
+          description: data.description || '',
+          unit_price: data.unit_price,
+          vat_rate: Number(data.vat_rate),
+          unit: data.unit || 'stk',
+          product_number: data.product_number || '',
+        });
+      } catch (error) {
+        console.error('Error fetching product:', error);
+        toast.error(t('Failed to load product'));
+        router.push('/products');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProduct();
+  }, [params.id]);
+
+  const handleSave = async () => {
+    if (!product) return;
+    setSaving(true);
+    try {
+      const nullIfBlank = (v: string) => (v.trim() === '' ? null : v);
+      const { error } = await supabase
+        .from('products')
+        .update({
+          name: formData.name,
+          description: nullIfBlank(formData.description),
+          unit_price: formData.unit_price,
+          vat_rate: formData.vat_rate,
+          unit: formData.unit.trim() || 'stk',
+          product_number: nullIfBlank(formData.product_number),
+        })
+        .eq('id', product.id);
+
+      if (error) throw error;
+
+      toast.success(t('Product updated successfully'));
+      router.refresh();
+    } catch (error) {
+      console.error('Error updating product:', error);
+      toast.error(t('Failed to update product'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!product) return;
+    if (!confirm(t('Are you sure you want to delete this product? This action cannot be undone.'))) return;
+    setDeleting(true);
+    try {
+      // Soft-delete: keep the row, drop it from the catalogue list.
+      const { error } = await supabase
+        .from('products')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('id', product.id);
+      if (error) throw error;
+      toast.success(t('Product deleted successfully'));
+      router.push('/products');
+    } catch (error) {
+      console.error('Error deleting product:', error);
+      toast.error(t('Failed to delete product'));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto py-8 px-4">
+        <div className="text-center">{t('Loading product...')}</div>
+      </div>
+    );
+  }
+
+  if (!product) return null;
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="mb-8">
+        <Link href="/products" className="inline-flex items-center text-muted-foreground hover:text-foreground mb-4">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          {t('Back to Products')}
+        </Link>
+        <div className="flex justify-between items-start">
+          <h1 className="text-3xl font-bold">{product.name}</h1>
+          <div className="flex items-center space-x-4">
+            <Button onClick={handleSave} disabled={saving}>
+              <Save className="h-4 w-4 mr-2" />
+              {saving ? t('Saving...') : t('Save Changes')}
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              <Trash className="h-4 w-4 mr-2" />
+              {deleting ? t('Deleting...') : t('Delete')}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-2xl">
+        <div className="bg-card p-6 rounded-lg border space-y-4">
+          <div>
+            <Label htmlFor="name">{t('Name')}</Label>
+            <Input
+              id="name"
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="description">{t('Description')}</Label>
+            <textarea
+              id="description"
+              className="w-full p-2 border rounded-md resize-none"
+              rows={3}
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              placeholder={t('Optional')}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="unit_price">{t('Unit Price')} (NOK)</Label>
+              <Input
+                id="unit_price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={formData.unit_price}
+                onChange={(e) => setFormData({ ...formData, unit_price: parseFloat(e.target.value) || 0 })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="vat_rate">{t('VAT Rate (%)')}</Label>
+              <Input
+                id="vat_rate"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                value={formData.vat_rate}
+                onChange={(e) => setFormData({ ...formData, vat_rate: parseFloat(e.target.value) || 0 })}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label htmlFor="unit">{t('Unit')}</Label>
+              <Input
+                id="unit"
+                value={formData.unit}
+                onChange={(e) => setFormData({ ...formData, unit: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="product_number">{t('Product No.')}</Label>
+              <Input
+                id="product_number"
+                value={formData.product_number}
+                onChange={(e) => setFormData({ ...formData, product_number: e.target.value })}
+                placeholder={t('Optional')}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/products/new/page.tsx
+++ b/src/app/products/new/page.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import Link from "next/link"
+import { createClient } from '@/utils/supabase/client';
+import { toast } from 'sonner';
+import { t } from '@/lib/i18n';
+
+export default function NewProductPage() {
+  const router = useRouter();
+  const supabase = createClient();
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    description: '',
+    unit_price: 0,
+    vat_rate: 25,
+    unit: 'stk',
+    product_number: '',
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      const { data: { user } } = await supabase.auth.getUser();
+
+      if (!user) {
+        toast.error(t('You must be logged in to create a product'));
+        return;
+      }
+
+      const payload: Record<string, unknown> = {
+        user_id: user.id,
+        name: formData.name,
+        unit_price: formData.unit_price,
+        vat_rate: formData.vat_rate,
+        unit: formData.unit.trim() || 'stk',
+      };
+      if (formData.description.trim()) payload.description = formData.description.trim();
+      if (formData.product_number.trim()) payload.product_number = formData.product_number.trim();
+
+      const { error } = await supabase.from('products').insert(payload);
+      if (error) throw error;
+
+      toast.success(t('Product created successfully!'));
+      router.push('/products');
+    } catch (error) {
+      console.error('Error creating product:', error);
+      toast.error(t('Failed to create product'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-10">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-bold">{t('Add New Product')}</h1>
+          <Link href="/products">
+            <Button variant="outline">{t('Cancel')}</Button>
+          </Link>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="space-y-2">
+            <Label htmlFor="name">{t('Name')} *</Label>
+            <Input
+              id="name"
+              placeholder={t('e.g. Konsulenttime')}
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">{t('Description')}</Label>
+            <textarea
+              id="description"
+              className="w-full p-2 border rounded-md resize-none"
+              rows={3}
+              placeholder={t('Optional description that prefills the invoice line')}
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="unit_price">{t('Unit Price')} (NOK) *</Label>
+              <Input
+                id="unit_price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={formData.unit_price}
+                onChange={(e) => setFormData({ ...formData, unit_price: parseFloat(e.target.value) || 0 })}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="vat_rate">{t('VAT Rate (%)')}</Label>
+              <Input
+                id="vat_rate"
+                type="number"
+                min="0"
+                max="100"
+                step="0.01"
+                value={formData.vat_rate}
+                onChange={(e) => setFormData({ ...formData, vat_rate: parseFloat(e.target.value) || 0 })}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="unit">{t('Unit')}</Label>
+              <Input
+                id="unit"
+                placeholder="stk / time / dag"
+                value={formData.unit}
+                onChange={(e) => setFormData({ ...formData, unit: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="product_number">{t('Product No.')}</Label>
+              <Input
+                id="product_number"
+                placeholder="K-001"
+                value={formData.product_number}
+                onChange={(e) => setFormData({ ...formData, product_number: e.target.value })}
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end space-x-4">
+            <Link href="/products">
+              <Button variant="outline">{t('Cancel')}</Button>
+            </Link>
+            <Button type="submit" disabled={loading}>
+              {loading ? t('Creating...') : t('Create Product')}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from "@/components/ui/button"
+import Link from "next/link"
+import { createClient } from '@/utils/supabase/client';
+import { toast } from 'sonner';
+import type { Product } from '@/types/database';
+import { t } from '@/lib/i18n';
+
+export default function ProductsPage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const supabase = createClient();
+
+  useEffect(() => {
+    const fetchProducts = async () => {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+
+        if (!user) {
+          toast.error(t('You must be logged in to view products'));
+          return;
+        }
+
+        const { data, error } = await supabase
+          .from('products')
+          .select('*')
+          .eq('user_id', user.id)
+          .is('deleted_at', null)
+          .order('name');
+
+        if (error) throw error;
+
+        setProducts(data || []);
+      } catch (error) {
+        console.error('Error fetching products:', error);
+        toast.error(t('Failed to load products'));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchProducts();
+  }, []);
+
+  return (
+    <div className="container mx-auto py-10">
+      <div className="flex justify-between items-center mb-8">
+        <h1 className="text-3xl font-bold">{t('Products')}</h1>
+        <Link href="/products/new">
+          <Button>{t('Add New Product')}</Button>
+        </Link>
+      </div>
+
+      <div className="bg-white rounded-lg shadow">
+        {loading ? (
+          <div className="p-4 text-center text-gray-500">{t('Loading products...')}</div>
+        ) : products.length === 0 ? (
+          <div className="p-4 text-center text-gray-500">
+            {t('No products found. Add your first product to get started.')}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-left p-4">{t('Name')}</th>
+                  <th className="text-left p-4">{t('Product No.')}</th>
+                  <th className="text-left p-4">{t('Unit')}</th>
+                  <th className="text-right p-4">{t('Unit Price')}</th>
+                  <th className="text-right p-4">{t('VAT')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {products.map((product) => (
+                  <tr key={product.id} className="border-b hover:bg-gray-50">
+                    <td className="p-4">
+                      <Link href={`/products/${product.id}`} className="text-primary hover:underline">
+                        {product.name}
+                      </Link>
+                    </td>
+                    <td className="p-4">{product.product_number || t('-')}</td>
+                    <td className="p-4">{product.unit}</td>
+                    <td className="p-4 text-right">{product.unit_price.toFixed(2)}</td>
+                    <td className="p-4 text-right">{Number(product.vat_rate)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -66,6 +66,7 @@ export default function Navbar() {
     ['/dashboard', t('Dashboard')],
     ['/invoices', t('Invoices')],
     ['/clients', t('Clients')],
+    ['/products', t('Products')],
     ['/settings', t('Settings')],
   ];
 

--- a/src/lib/validations/invoice.ts
+++ b/src/lib/validations/invoice.ts
@@ -63,6 +63,18 @@ export const createClientSchema = z.object({
   peppol_endpoint: z.string().max(60).optional(),
 });
 
+// Product catalogue entry (reusable invoice-line template).
+export const createProductSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  unit_price: z.number().nonnegative().max(10000000),
+  vat_rate: z.number().min(0).max(100).default(25),
+  unit: z.string().max(20).optional(),
+  unit_code: z.string().max(10).optional(),
+  product_number: z.string().max(60).optional(),
+});
+
+export type CreateProductInput = z.infer<typeof createProductSchema>;
 export type CreateInvoiceInput = z.infer<typeof createInvoiceSchema>;
 export type UpdateInvoiceInput = z.infer<typeof updateInvoiceSchema>;
 export type CreateClientInput = z.infer<typeof createClientSchema>;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -27,6 +27,21 @@ export interface Profile {
   created_at: string;
 }
 
+export interface Product {
+  id: string;
+  user_id: string;
+  name: string;
+  description?: string | null;
+  unit_price: number;
+  vat_rate: number;
+  unit: string;
+  unit_code: string;
+  product_number?: string | null;
+  deleted_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface Invoice {
   id: string;
   invoice_number: string;

--- a/supabase/migrations/20260605130000_products.sql
+++ b/supabase/migrations/20260605130000_products.sql
@@ -1,0 +1,57 @@
+-- Products catalogue — reusable invoice-line templates, managed the same way as
+-- clients (per-user, RLS-scoped, soft-deletable). A product prefills an invoice
+-- line's description / price / VAT / unit on the create page.
+--
+-- Mirrors the clients table: user_id is TEXT (auth.uid()::text), RLS scoped to
+-- the owner, plus the shared set_user_id / prevent_user_id_change / handle_
+-- updated_at triggers (all defined in earlier migrations).
+
+create table if not exists public.products (
+  id             uuid not null default gen_random_uuid(),
+  user_id        text not null,
+  name           text not null,
+  description    text,
+  unit_price     numeric not null default 0,        -- NOK
+  vat_rate       numeric(5,2) not null default 25,  -- percent; forced to 0 at
+                                                     -- invoice time for non-VAT-
+                                                     -- registered sellers
+  unit           text not null default 'stk',       -- human label (stk, time, …)
+  unit_code      text not null default 'C62',        -- UN/ECE Rec 20 for EHF
+  product_number text,                               -- optional SKU
+  deleted_at     timestamptz,
+  created_at     timestamptz default now(),
+  updated_at     timestamptz default now(),
+  constraint products_pkey primary key (id)
+);
+
+create index if not exists idx_products_user_id    on public.products(user_id);
+create index if not exists idx_products_deleted_at on public.products(deleted_at);
+
+alter table public.products enable row level security;
+
+create policy "Users can view their own products" on public.products
+  for select using (auth.uid()::text = user_id);
+
+create policy "Users can insert their own products" on public.products
+  for insert with check (auth.uid()::text = user_id);
+
+create policy "Users can update their own products" on public.products
+  for update using (auth.uid()::text = user_id)
+  with check (auth.uid()::text = user_id);
+
+create policy "Users can delete their own products" on public.products
+  for delete using (auth.uid()::text = user_id);
+
+-- updated_at maintenance
+create trigger handle_products_updated_at
+  before update on public.products
+  for each row execute function public.handle_updated_at();
+
+-- user_id auto-fill on insert + immutability on update (parity with clients)
+create trigger set_user_id_trigger_products
+  before insert on public.products
+  for each row execute function public.set_user_id();
+
+create trigger prevent_user_id_change_products
+  before update on public.products
+  for each row execute function public.prevent_user_id_change();


### PR DESCRIPTION
Adds a **Products** overview managed the same way as Clients/customers, plus a per-line product picker on invoice creation.

## What's in it
- **`products` table** (`20260605130000_products.sql`) mirroring `clients`: per-user, RLS-scoped (`auth.uid()::text = user_id`), soft-deletable, with the shared `set_user_id` / `prevent_user_id_change` / `handle_updated_at` triggers. Fields: `name`, `description`, `unit_price` (NOK), `vat_rate`, `unit`, `unit_code` (EHF UN/ECE), `product_number`.
- **`Product` type** + `createProductSchema`.
- **API**: `/api/products` (GET/POST) + `/api/products/[id]` (GET/PUT/DELETE) — direct mirror of the clients routes.
- **Pages**: `/products` (overview), `/products/new`, `/products/[id]` (edit + soft-delete). **Products** nav entry added.
- **Invoice create wiring**: each line gets a "Velg produkt" picker that prefills description/price/VAT. Respects the seller's VAT status — a non-VAT-registered seller's lines stay 0% (consistent with Phase 5).

## Notes
- UI uses the supabase client directly (same pattern as the clients pages); RLS enforces ownership. API routes exist for parity/programmatic use.
- Migration applies automatically via the deploy workflow on merge to `main`.
- `unit_code` is stored for future EHF use; the invoice-line form doesn't yet thread a per-line unit_code (lines default to C62 as before).

## Verification
- `tsc --noEmit` clean; `next build` succeeds (new routes compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)